### PR TITLE
Support path based payload filters

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -69,13 +69,6 @@
     "os": "OS X",
     "os_version": "high sierra"
   },
-  "bs_iphone": {
-    "base": "BrowserStack",
-    "browser": "iphone",
-    "device": "iPhone 4S (6.0)",
-    "os": "ios",
-    "os_version": "6.0"
-  },
   "bs_android": {
     "base": "BrowserStack",
     "browser": "Android Browser",

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function prepareObjForSerialization (obj, filterKeys, filterPaths) {
       for (var prop in obj) {
         if (!Object.prototype.hasOwnProperty.call(obj, prop)) continue
         if (isDescendent(filterPaths, path.join('.')) && shouldFilter(filterKeys, prop)) {
-          result[prop] = '[FILTERED]'
+          result[prop] = '[Filtered]'
           continue
         }
         if (edgesExceeded()) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 module.exports = function (data, replacer, space, opts) {
   var filterKeys = opts && opts.filterKeys ? opts.filterKeys : []
   var filterPaths = opts && opts.filterPaths ? opts.filterPaths : []
-  return JSON.stringify(ensureProperties(data, filterKeys, filterPaths), replacer, space)
+  return JSON.stringify(
+    prepareObjForSerialization(data, filterKeys, filterPaths),
+    replacer,
+    space
+  )
 }
 
 var MAX_DEPTH = 20
@@ -49,19 +53,18 @@ function safelyGetProp (obj, prop) {
   }
 }
 
-function ensureProperties (obj, filterKeys, filterPaths) {
+function prepareObjForSerialization (obj, filterKeys, filterPaths) {
   var seen = [] // store references to objects we have seen before
   var edges = 0
 
-  function visit (obj, depth, path) {
+  function visit (obj, path) {
     function edgesExceeded () {
-      return depth > MIN_PRESERVED_DEPTH && edges > MAX_EDGES
+      return path.length > MIN_PRESERVED_DEPTH && edges > MAX_EDGES
     }
 
     edges++
 
-    if (depth === undefined) depth = 0
-    if (depth > MAX_DEPTH) return REPLACEMENT_NODE
+    if (path.length > MAX_DEPTH) return REPLACEMENT_NODE
     if (edgesExceeded()) return REPLACEMENT_NODE
     if (obj === null || typeof obj !== 'object') return obj
     if (find(seen, obj)) return '[Circular]'

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function isDescendent (paths, path) {
 function shouldFilter (patterns, key) {
   for (var i = 0, len = patterns.length; i < len; i++) {
     if (typeof patterns[i] === 'string' && patterns[i] === key) return true
-    if (patterns[i] && patterns[i].test && patterns[i].test(key)) return true
+    if (patterns[i] && typeof patterns[i].test === 'function' && patterns[i].test(key)) return true
   }
   return false
 }

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function prepareObjForSerialization (obj, filterKeys, filterPaths) {
         // we're not going to count this as an edge because it
         // replaces the value of the currently visited object
         edges--
-        var fResult = visit(obj.toJSON(), depth, path)
+        var fResult = visit(obj.toJSON(), path)
         seen.pop()
         return fResult
       } catch (err) {
@@ -91,7 +91,7 @@ function prepareObjForSerialization (obj, filterKeys, filterPaths) {
           aResult.push(REPLACEMENT_NODE)
           break
         }
-        aResult.push(visit(obj[i], depth + 1, path.concat('[]')))
+        aResult.push(visit(obj[i], path.concat('[]')))
       }
       seen.pop()
       return aResult
@@ -109,12 +109,12 @@ function prepareObjForSerialization (obj, filterKeys, filterPaths) {
           result[prop] = REPLACEMENT_NODE
           break
         }
-        result[prop] = visit(safelyGetProp(obj, prop), depth + 1, path.concat(prop))
+        result[prop] = visit(safelyGetProp(obj, prop), path.concat(prop))
       }
     } catch (e) {}
     seen.pop()
     return result
   }
 
-  return visit(obj, 0, [])
+  return visit(obj, [])
 }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function find (haystack, needle) {
 }
 
 // returns true if the string `path` starts with any of the provided `paths`
-function isDecendent (paths, path) {
+function isDescendent (paths, path) {
   for (var i = 0, len = paths.length; i < len; i++) {
     if (path.indexOf(paths[i]) === 0) return true
   }
@@ -98,7 +98,7 @@ function ensureProperties (obj, filterKeys, filterPaths) {
     try {
       for (var prop in obj) {
         if (!Object.prototype.hasOwnProperty.call(obj, prop)) continue
-        if (isDecendent(filterPaths, path.join('.')) && shouldFilter(filterKeys, prop)) {
+        if (isDescendent(filterPaths, path.join('.')) && shouldFilter(filterKeys, prop)) {
           result[prop] = '[FILTERED]'
           continue
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/safe-json-stringify",
-  "version": "2.1.0",
+  "version": "3.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "git@github.com:bugsnag/safe-json-stringify.git"
   },
+  "files": [
+    "index.js"
+  ],
   "bugs": {
     "url": "https://github.com/bugsnag/safe-json-stringify/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/safe-json-stringify",
-  "version": "2.1.0",
+  "version": "3.0.0-0",
   "repository": {
     "type": "git",
     "url": "git@github.com:bugsnag/safe-json-stringify.git"

--- a/test/fixtures/01-example-payload.json
+++ b/test/fixtures/01-example-payload.json
@@ -1,0 +1,111 @@
+{
+  "apiKey": "d145b8e5afb56516423bc4d605e45442",
+  "notifier": {
+    "name": "Bugsnag Node",
+    "version": "1.0.0",
+    "url": "https://github.com/bugsnag/bugsnag-js"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "exceptions": [
+        {
+          "errorClass": "Error",
+          "message": "ENOENT: no such file or directory, open 'does not exist'",
+          "stacktrace": [
+            {
+              "file": "scenarios/contextualize.js",
+              "method": "Object.<anonymous>",
+              "lineNumber": 12,
+              "columnNumber": 1,
+              "code": {
+                "9": "})",
+                "10": "",
+                "11": "var contextualize = bugsnagClient.getPlugin('contextualize')",
+                "12": "contextualize(function () {",
+                "13": "  fs.createReadStream('does not exist')",
+                "14": "}, {",
+                "15": "  metaData: {"
+              },
+              "inProject": true
+            },
+            {
+              "file": "module.js",
+              "method": "Module._compile",
+              "lineNumber": 409,
+              "columnNumber": 26,
+              "inProject": false
+            },
+            {
+              "file": "module.js",
+              "method": "Object.Module._extensions..js",
+              "lineNumber": 416,
+              "columnNumber": 10,
+              "inProject": false
+            },
+            {
+              "file": "module.js",
+              "method": "Module.load",
+              "lineNumber": 343,
+              "columnNumber": 32,
+              "inProject": false
+            },
+            {
+              "file": "module.js",
+              "method": "Function.Module._load",
+              "lineNumber": 300,
+              "columnNumber": 12,
+              "inProject": false
+            },
+            {
+              "file": "module.js",
+              "method": "Function.Module.runMain",
+              "lineNumber": 441,
+              "columnNumber": 10,
+              "inProject": false
+            },
+            {
+              "file": "node.js",
+              "method": "startup",
+              "lineNumber": 140,
+              "columnNumber": 18,
+              "inProject": false
+            },
+            {
+              "file": "node.js",
+              "lineNumber": 1043,
+              "columnNumber": 3,
+              "inProject": false
+            }
+          ],
+          "type": "nodejs"
+        }
+      ],
+      "severity": "error",
+      "unhandled": true,
+      "severityReason": {
+        "type": "unhandledException"
+      },
+      "app": {
+        "releaseStage": "production"
+      },
+      "device": {
+        "hostname": "cd1e0e7b700a",
+        "time": "2018-08-16T14:08:02.240Z"
+      },
+      "breadcrumbs": [
+
+      ],
+      "user": {
+      },
+      "metaData": {
+        "subsystem": {
+          "name": "fs reader",
+          "widgetsAdded": 10
+        }
+      },
+      "request": {
+      }
+    }
+  ]
+}

--- a/test/safe-json-stringify.test.js
+++ b/test/safe-json-stringify.test.js
@@ -204,3 +204,41 @@ function nest (n, m) {
   }
   return o
 }
+
+describe('filter options', () => {
+  it('should filter nothing by default', () => {
+    const fixture = require('./fixtures/01-example-payload.json')
+    expect(safeJsonStringify(fixture)).toBe(JSON.stringify(fixture))
+  })
+
+  it('should only filter paths that are in "filterPaths"', () => {
+    const fixture = require('./fixtures/01-example-payload.json')
+    expect(
+      safeJsonStringify(fixture, null, null, { filterKeys: [ 'subsystem' ] })
+    ).toBe(JSON.stringify(fixture))
+    expect(
+      safeJsonStringify(fixture, null, null, {
+        filterKeys: [ 'subsystem' ],
+        filterPaths: [ 'events.[].metaData' ]
+      })
+    ).toBe(JSON.stringify(fixture).replace('{"name":"fs reader","widgetsAdded":10}', '"[FILTERED]"'))
+  })
+
+  it('should work with regexes', () => {
+    const fixture = require('./fixtures/01-example-payload.json')
+    expect(
+      safeJsonStringify(fixture, null, null, { filterKeys: [ 'subsystem' ] })
+    ).toBe(JSON.stringify(fixture))
+    expect(
+      safeJsonStringify(fixture, null, null, {
+        filterKeys: [ /na*/, /widget(s?)added/i ],
+        filterPaths: [ 'events.[].metaData' ]
+      })
+    ).toBe(
+      JSON.stringify(fixture).replace(
+        '{"name":"fs reader","widgetsAdded":10}',
+        '{"name":"[FILTERED]","widgetsAdded":"[FILTERED]"}'
+      )
+    )
+  })
+})

--- a/test/safe-json-stringify.test.js
+++ b/test/safe-json-stringify.test.js
@@ -205,14 +205,14 @@ function nest (n, m) {
   return o
 }
 
-describe('filter options', () => {
-  it('should filter nothing by default', () => {
-    const fixture = require('./fixtures/01-example-payload.json')
+describe('filter options', function () {
+  it('should filter nothing by default', function () {
+    var fixture = require('./fixtures/01-example-payload.json')
     expect(safeJsonStringify(fixture)).toBe(JSON.stringify(fixture))
   })
 
-  it('should only filter paths that are in "filterPaths"', () => {
-    const fixture = require('./fixtures/01-example-payload.json')
+  it('should only filter paths that are in "filterPaths"', function () {
+    var fixture = require('./fixtures/01-example-payload.json')
     expect(
       safeJsonStringify(fixture, null, null, { filterKeys: [ 'subsystem' ] })
     ).toBe(JSON.stringify(fixture))
@@ -224,8 +224,8 @@ describe('filter options', () => {
     ).toBe(JSON.stringify(fixture).replace('{"name":"fs reader","widgetsAdded":10}', '"[FILTERED]"'))
   })
 
-  it('should work with regexes', () => {
-    const fixture = require('./fixtures/01-example-payload.json')
+  it('should work with regexes', function () {
+    var fixture = require('./fixtures/01-example-payload.json')
     expect(
       safeJsonStringify(fixture, null, null, { filterKeys: [ 'subsystem' ] })
     ).toBe(JSON.stringify(fixture))

--- a/test/safe-json-stringify.test.js
+++ b/test/safe-json-stringify.test.js
@@ -221,7 +221,7 @@ describe('filter options', function () {
         filterKeys: [ 'subsystem' ],
         filterPaths: [ 'events.[].metaData' ]
       })
-    ).toBe(JSON.stringify(fixture).replace('{"name":"fs reader","widgetsAdded":10}', '"[FILTERED]"'))
+    ).toBe(JSON.stringify(fixture).replace('{"name":"fs reader","widgetsAdded":10}', '"[Filtered]"'))
   })
 
   it('should work with regexes', function () {
@@ -237,7 +237,7 @@ describe('filter options', function () {
     ).toBe(
       JSON.stringify(fixture).replace(
         '{"name":"fs reader","widgetsAdded":10}',
-        '{"name":"[FILTERED]","widgetsAdded":"[FILTERED]"}'
+        '{"name":"[Filtered]","widgetsAdded":"[Filtered]"}'
       )
     )
   })


### PR DESCRIPTION
This PR adds support for filtering payload properties based on their key, which should only be applied to specified subtrees. This facilitates the changes required in https://github.com/bugsnag/bugsnag-js/pull/386.

Here is an example usage of the new feature:

```js
var stringify = require('@bugsnag/safe-json-stringify')
stringify({
  api_key: 'd145b8e5afb56516423bc4d605e45442',
  events: [
    {
      errorMessage: 'Failed load tickets',
      errorClass: 'CheckoutError',
      user: {
        name: 'Jim Bug',
        email: 'jim@bugsnag.com',
        api_key: '245b39ebd3cd3992e85bffc81c045924'
      }
    }
  ]
}, null, 2, {
  filterKeys: [ 'api_key' ],
  filterPaths: [ 'events.[].user' ]
})
// yields the following json:
// {
//   "api_key": "d145b8e5afb56516423bc4d605e45442",
//   "events": [
//     {
//       "errorMessage": "Failed load tickets",
//       "errorClass": "CheckoutError",
//       "user": {
//         "name": "Jim Bug",
//         "email": "jim@bugsnag.com",
//         "api_key": "[FILTERED]"
//       }
//     }
//   ]
// }
```

Even though this is backwards compatible, I think this is a big enough change to warrant a major version bump. I've tagged a prerelease and pushed it to npm `v3.0.0-0` in order to test on the @bugsnag/js PR.