### PR TITLE
Serialise errors in a useful way

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ var MIN_PRESERVED_DEPTH = 8
 
 var REPLACEMENT_NODE = '...'
 
+function isError (o) {
+  return o instanceof Error ||
+    /^\[object (Error|(Dom)?Exception)\]$/.test(Object.prototype.toString.call(o))
+}
+
 function throwsMessage (err) {
   return '[Throws: ' + (err ? err.message : '?') + ']'
 }
@@ -82,6 +87,14 @@ function prepareObjForSerialization (obj, filterKeys, filterPaths) {
       } catch (err) {
         return throwsMessage(err)
       }
+    }
+
+    var er = isError(obj)
+    if (er) {
+      edges--
+      var eResult = visit({ name: obj.name, message: obj.message }, path)
+      seen.pop()
+      return eResult
     }
 
     if (isArray(obj)) {

--- a/test/safe-json-stringify.test.js
+++ b/test/safe-json-stringify.test.js
@@ -53,6 +53,13 @@ describe('arrays', function () {
   })
 })
 
+describe('errors', function () {
+  it('should extract meaningful error properties', function () {
+    var err = new Error('hello')
+    expect(safeJsonStringify(err)).toBe('{"name":"Error","message":"hello"}')
+  })
+})
+
 describe('throwing toJSON', function () {
   it('works when obj.toJSON() throws an error', function () {
     var obj = {

--- a/test/safe-json-stringify.test.js
+++ b/test/safe-json-stringify.test.js
@@ -183,7 +183,7 @@ describe('widely nested', function () {
     expect(str.indexOf('...')).toBeGreaterThan(1)
   })
   it('should not replace objects less than the MIN_PRESERVED_DEPTH', function () {
-    var o = { a: nest(2, 2000) }
+    var o = { a: nest(2, 1500) }
     var str = safeJsonStringify(o)
     expect(str.indexOf('...')).toBe(-1)
   })


### PR DESCRIPTION
Previously this library would encode errors an an empty object (see https://github.com/bugsnag/bugsnag-js/issues/356) because they have no enumerable keys.

This change detects when the object is an error and if so, grabs its `name` and `message` properties.

Optionally we could attempt to get the stack too but I opted not to.