### PR TITLE
Make string matching case insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The API is the same as `JSON.stringify`, with an additional `options` object:
 stringify(obj, [optional replacer], [optional spaces], [options])
 ```
 
-- `options.redactedKeys`: a list of keys whose value should be replaced with the string `[REDACTED]`. Keys can be strings for exact matches, or regexes for partial or pattern matches. The array can contain a mixture of both.
+- `options.redactedKeys`: a list of keys whose value should be replaced with the string `[REDACTED]`. Keys can be strings for case insensitive matches, or regexes for partial or pattern matches. The array can contain a mixture of both.
 - `options.redactedPaths`: a list of paths where the `redactedKeys` option will be applied. The format of these strings are key names separated by `.` and if the property is an array, it is represented with `[]`. For example: `events.[].metaData`.
 
 ### Example

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function isDescendent (paths, path) {
 
 function shouldRedact (patterns, key) {
   for (var i = 0, len = patterns.length; i < len; i++) {
-    if (typeof patterns[i] === 'string' && patterns[i] === key) return true
+    if (typeof patterns[i] === 'string' && patterns[i].toLowerCase() === key.toLowerCase()) return true
     if (patterns[i] && typeof patterns[i].test === 'function' && patterns[i].test(key)) return true
   }
   return false

--- a/test/safe-json-stringify.test.js
+++ b/test/safe-json-stringify.test.js
@@ -231,6 +231,21 @@ describe('redaction options', function () {
     ).toBe(JSON.stringify(fixture).replace('{"name":"fs reader","widgetsAdded":10}', '"[REDACTED]"'))
   })
 
+  it('should ignore case when redacting keys', function () {
+    var fixture = require('./fixtures/01-example-payload.json')
+
+    expect(
+      safeJsonStringify(fixture, null, null, { redactedKeys: [ 'SuBsYsTeM' ] })
+    ).toBe(JSON.stringify(fixture))
+
+    expect(
+      safeJsonStringify(fixture, null, null, {
+        redactedKeys: [ 'SuBsYsTeM' ],
+        redactedPaths: [ 'events.[].metaData' ]
+      })
+    ).toBe(JSON.stringify(fixture).replace('{"name":"fs reader","widgetsAdded":10}', '"[REDACTED]"'))
+  })
+
   it('should work with regexes', function () {
     var fixture = require('./fixtures/01-example-payload.json')
     expect(


### PR DESCRIPTION
This PR changes string matching to be case insensitive as this is almost always what is intended, e.g. `password` should match `Password` and `PASSWORD`

This only applies to the `redactedKeys` option; `redactedPaths` is still case sensitive because we don't expose it as an option in the notifier