### PR TITLE
Add type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/bugsnag/safe-json-stringify",
   "description": "Prevent defined property getters from throwing errors",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "postversion": "git push && git push --tags",
     "preversion": "npm test",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "url": "git@github.com:bugsnag/safe-json-stringify.git"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "types"
   ],
   "bugs": {
     "url": "https://github.com/bugsnag/safe-json-stringify/issues"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,23 @@
+declare module '@bugsnag/safe-json-stringify' {
+      /**
+     * Safely converts a JavaScript object to a JSON string.
+     * If the object contains circular references, they will be replaced with `[Circular]`.
+     *
+     * @param value - The value to stringify.
+     * @param replacer - A function that alters the behavior of the stringification process, or an array of String and Number objects that serve as a whitelist for selecting/filtering the properties of the value object to be included in the JSON string.
+     * @param space - A String or Number object that's used to insert white space into the output JSON string for readability purposes.
+     * @param options - An object containing options for redacting keys and paths.
+     * @param options.redactedKeys - An array of keys or regular expressions that should be redacted from the output.
+     * @param options.redactedPaths - An array of strings representing paths to properties that should be redacted from the output.
+     * @returns The JSON string representation of the value.
+     */
+    export default function stringify(
+        value: any,
+        replacer?: null | ((this: any, key: string, value: any) => any), 
+        space?: null | string | number,
+        options?: {
+            redactedKeys?: Array<string | RegExp>;
+            redactedPaths?: string[];
+        }
+    ): string;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,8 +13,8 @@ declare module '@bugsnag/safe-json-stringify' {
      */
     export default function stringify(
         value: any,
-        replacer?: null | ((this: any, key: string, value: any) => any), 
-        space?: null | string | number,
+        replacer?: ((this: any, key: string, value: any) => any) | undefined, 
+        space?: string | number | undefined,
         options?: {
             redactedKeys?: Array<string | RegExp>;
             redactedPaths?: string[];


### PR DESCRIPTION
This PR adds TypeScript type definitions to the safe-json-stringify package. The change enables TypeScript developers to use this package with proper type checking support.

Validated configuration using [arethetypeswrong](https://arethetypeswrong.github.io/)